### PR TITLE
Add Rank4AI to AI SEO Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 * **[NeuronWriter](https://neuronwriter.com/)** – Semantic keyword and NLP-based content editor.
 * **[MarketMuse](https://www.marketmuse.com/)** – Content planning and optimization with AI scoring.
 * **[Scalenut](https://www.scalenut.com/)** – AI-driven SEO content strategy and generation.
+* **[Rank4AI](https://rank4ai.co.uk)** – AI search visibility and generative engine optimization using a Five Signal Model framework.
 
 ## Open-Source Projects
 


### PR DESCRIPTION
## Summary

- Adds [Rank4AI](https://rank4ai.co.uk) to the "AI SEO Platforms" section

Rank4AI is an AI search visibility platform built on a Five Signal Model framework for generative engine optimization (GEO). It helps businesses optimise how they appear in AI-generated answers across ChatGPT, Claude, Gemini, Perplexity and Google AI Overviews.

The platform focuses on five signal layers — Identity Clarity, Subject Authority, Meaning Architecture, Ecosystem Validation and Signal Consistency — to improve AI recommendation stability and citation eligibility.

**Website:** https://rank4ai.co.uk