### PR TITLE
Add AEOrank to Open-Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 * **[GPTSEO](https://github.com/gptseo/gptseo)** – AI SEO tool for generating articles and optimizing titles/meta.
 * **[Keyword Clustering Tool (Python)](https://github.com/AndreiMikhalevich/KeywordClustering)** – Cluster keywords using embeddings.
 * **[GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker)** – Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, free, with visibility scoring, citation analysis, and competitor battlecards.
+* **[AEOrank](https://github.com/vinpatel/aeorank)** – Open-source AEO scoring CLI that scans websites for AI engine visibility, scores 0–100, and generates AI-readable files. 13 framework plugins and a GitHub Action. ([aeorank.dev](https://aeorank.dev))
 
 ## Keyword Research & Clustering
 


### PR DESCRIPTION
## Summary

- Adds [AEOrank](https://github.com/vinpatel/aeorank) to the **Open-Source Projects** section
- AEOrank is an MIT-licensed AEO scoring CLI that scans websites for AI engine visibility, scores 0–100, and generates AI-readable files
- Includes 13 framework plugins (Next.js, Astro, Nuxt, Remix, SvelteKit, Gatsby, etc.) and a GitHub Action
- Website: [aeorank.dev](https://aeorank.dev)