### PR TITLE
Add toprank to Open-Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 * **[GPTSEO](https://github.com/gptseo/gptseo)** – AI SEO tool for generating articles and optimizing titles/meta.
 * **[Keyword Clustering Tool (Python)](https://github.com/AndreiMikhalevich/KeywordClustering)** – Cluster keywords using embeddings.
 * **[GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker)** – Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, free, with visibility scoring, citation analysis, and competitor battlecards.
+* **[toprank](https://github.com/nowork-studio/toprank)** – Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic and wasted spend, rewrites meta tags, generates JSON-LD schema markup, and ships fixes to WordPress, Strapi, Contentful, or Ghost.
 
 ## Keyword Research & Clustering
 


### PR DESCRIPTION
Adds **toprank** under Open-Source Projects.

toprank is an open-source (MIT) Claude Code plugin providing 9 SEO and Google Ads skills. It connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic and wasted ad spend, then ships fixes — meta tag rewrites, JSON-LD schema markup, heading hierarchy corrections — directly to source code or CMS (WordPress, Strapi, Contentful, Ghost).

- Source: https://github.com/nowork-studio/toprank
- License: MIT
- Stars: 100+ · Actively maintained with CHANGELOG, tests, and eval harness