### PR TITLE
Add SEO for AI to AI SEO Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 * **[NeuronWriter](https://neuronwriter.com/)** – Semantic keyword and NLP-based content editor.
 * **[MarketMuse](https://www.marketmuse.com/)** – Content planning and optimization with AI scoring.
 * **[Scalenut](https://www.scalenut.com/)** – AI-driven SEO content strategy and generation.
+* **[SEO for AI](https://getseoforai.com/)** – AI visibility audits for small businesses. Free citation checker plus a $197 full report covering ChatGPT, Perplexity, Claude, Gemini, and Google AI Overviews.
 
 ## Open-Source Projects
 


### PR DESCRIPTION
Adding SEO for AI under AI SEO Platforms. Small-business focus, free checker, $197 audit. Covers ChatGPT, Perplexity, Claude, Gemini, and Google AI Overviews.

- https://getseoforai.com/
- Free checker: https://getseoforai.com/checker