### PR TITLE
Add Linksii to SERP Tracking & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 
 * **[SE Ranking](https://seranking.com/)** – AI and machine learning tools for keyword tracking.
 * **[AccuRanker](https://www.accuranker.com/)** – SERP tracking with AI insights.
+* **[Linksii](https://www.linksii.com/)** – AI search visibility platform. Monitors how brands appear across ChatGPT, Claude, Gemini, and Perplexity with daily tracking, sentiment analysis, and source citation scoring.
 * **[Nightwatch](https://nightwatch.io/)** – Search visibility and rank tracking.
 * **[Google Search Console](https://search.google.com/search-console/about)** – Track performance in search (basic AI insights included).
 


### PR DESCRIPTION
Adds [Linksii](https://www.linksii.com/) to the SERP Tracking & Analytics section.

Linksii is an AI search visibility platform that monitors how brands appear across ChatGPT, Claude, Gemini, and Perplexity. It provides daily automated tracking, sentiment analysis, and source citation scoring.

It fills a gap in the current list — the existing tools focus on traditional SERP tracking, while Linksii specifically covers AI assistant search results.