### PR TITLE
Add Parse to AI SEO Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 * **[MarketMuse](https://www.marketmuse.com/)** – Content planning and optimization with AI scoring.
 * **[Scalenut](https://www.scalenut.com/)** – AI-driven SEO content strategy and generation.
 * **[oohoom](https://www.oohoom.com)** – Get the most out of your GSC and GA4 using AI Assistant and MCP
+* **[Parse](https://parse.gl/)** – AI brand visibility analytics tracking ChatGPT and Google AI Overviews with Parse Score benchmarks and competitor battlecards.
 
 ## Open-Source Projects
 


### PR DESCRIPTION
Adds Parse (https://parse.gl/) to the AI SEO Platforms section.

Parse is an AI brand visibility analytics platform that tracks how brands appear in ChatGPT and Google AI Overviews, with Parse Score benchmarks, competitor battlecards, and citation diagnostics. Same shape as the other AI SEO platforms in that section.

Single-line addition; format matches the existing entries (asterisk bullet, bold name, en-dash separator).