### PR TITLE
Add AI Visibility Monitor (AVM) to Open-Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 
 ## Open-Source Projects
 
+* **[AI Visibility Monitor (AVM)](https://github.com/WorkSmartAI-alt/ai-visibility-monitor)** – Open-source CLI that tracks AI search engine citations across Claude, ChatGPT, and Perplexity. Multi-engine in one run, Haiku 4.5 default at ~$0.30 per weekly run. Includes adjacent query discovery (`--expand`), source-surface categorization, and trajectory tracking (`avm trend`). No SaaS, no signup, customer owns the data.
 * **[seo-analyzer](https://github.com/stevenbenner/seo-analyzer)** – Command-line SEO audit tool.
 * **[GPTSEO](https://github.com/gptseo/gptseo)** – AI SEO tool for generating articles and optimizing titles/meta.
 * **[Keyword Clustering Tool (Python)](https://github.com/AndreiMikhalevich/KeywordClustering)** – Cluster keywords using embeddings.


### PR DESCRIPTION
Add AI Visibility Monitor (AVM) to Monitoring / Analytics

AVM is an open-source CLI that tracks how AI search engines cite your domain. It runs Claude + ChatGPT + Perplexity in one command and returns a unioned citation set with per-engine breakdown, source-surface categorization (press / blog / forum / etc.), and trajectory across historical runs.

Default model is Haiku 4.5, putting weekly cost at ~$0.30 per run for a 5-query base set. There is also an `--expand` mode for adjacent query discovery that ranks expansion queries by winnability score.

Free, MIT-licensed, no SaaS, no signup. Customer keeps all data locally. Maintained by Work-Smart.ai (Fractional Head of AI consulting practice).

Repo: https://github.com/WorkSmartAI-alt/ai-visibility-monitor

Per the contribution guide in this repo, I have:
- Confirmed the project is actively maintained (4 releases in 5 days)
- Linked from a credible domain (work-smart.ai)
- Followed the alphabetical order in the Open-Source Projects section

Thanks for considering.