### PR TITLE
Add Arenza to AI SEO Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 * **[NeuronWriter](https://neuronwriter.com/)** – Semantic keyword and NLP-based content editor.
 * **[MarketMuse](https://www.marketmuse.com/)** – Content planning and optimization with AI scoring.
 * **[Scalenut](https://www.scalenut.com/)** – AI-driven SEO content strategy and generation.
+* **[Arenza](https://arenza.ai/)** – Generative Engine Optimization platform measuring brand visibility, share of voice, sentiment, and citations across ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok.
 
 ## Open-Source Projects
 


### PR DESCRIPTION
Adds Arenza to the AI SEO Platforms section.

Arenza is a Generative Engine Optimization (GEO) platform that measures brand visibility, share of voice, sentiment, and citations across ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok. It complements existing entries like Surfer SEO and the GEO/AEO Tracker (Open-Source Projects) by focusing specifically on AI-search visibility measurement.

Project links:
- Website: https://arenza.ai
- Docs: https://arenza.ai/guides

Single-line entry following the existing bold-link-em-dash format. Placed at the bottom of the AI SEO Platforms section.