### PR TITLE
Add Dualmark to Open-Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 * **[GPTSEO](https://github.com/gptseo/gptseo)** – AI SEO tool for generating articles and optimizing titles/meta.
 * **[Keyword Clustering Tool (Python)](https://github.com/AndreiMikhalevich/KeywordClustering)** – Cluster keywords using embeddings.
 * **[GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker)** – Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, free, with visibility scoring, citation analysis, and competitor battlecards.
+* **[Dualmark](https://github.com/dodopayments/dualmark)** – Open-source AEO/GEO infrastructure. Auto-generates markdown twins of every page (e.g. `/pricing.md`) and serves them to AI crawlers (GPTBot, ClaudeBot, PerplexityBot, +16 known UAs) via HTTP content negotiation, while humans get HTML — same URL, two formats. Adapters for Astro, Next.js, Cloudflare Workers. Apache 2.0, npm provenance attested. Includes a conformance CLI (`dualmark verify <url>`) that scores any site 0–125 against a public AEO spec.
 
 ## Keyword Research & Clustering
 


### PR DESCRIPTION
Adds [Dualmark](https://github.com/dodopayments/dualmark) to the **Open-Source Projects** section, alongside GEO/AEO Tracker.

**What it is:** Open-source AEO/GEO infrastructure. Auto-generates a markdown twin of every page (e.g. `/pricing.md`) and serves it to AI crawlers (GPTBot, ClaudeBot, PerplexityBot, +16 known UAs) via HTTP content negotiation, while humans still get HTML — same URL, two formats. TypeScript adapters for Astro, Next.js, and Cloudflare Workers.

**Why next to GEO/AEO Tracker:** The two compose. GEO/AEO Tracker *measures* AI search visibility; Dualmark *publishes* the markdown twins that make sites visible in the first place.

- Apache 2.0, 313 tests, 125/125 on dualmark.dev's own conformance suite
- npm provenance attested (Sigstore-signed)
- Public RFC-2119 AEO Spec: https://github.com/dodopayments/dualmark/tree/main/spec
- Live: https://dualmark.dev

Happy to adjust placement or wording.