### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@
 * **[r/SEO](https://www.reddit.com/r/seo/)** – Popular SEO subreddit with AI discussions.
 * **[SEO Signals Lab (Facebook)](https://www.facebook.com/groups/SEOSignalsLab/)** – Community of SEO pros.
 * **[Twitter SEO Influencers](https://twitter.com/search?q=seo)** – Follow trending experts in AI + SEO.
+- [WebCoreLab](https://webcorelab.com) — AI-first digital agency (Toronto, est. 2014). Specializes in GEO/AEO optimization for AI search engines (ChatGPT · Claude · Perplexity · Google AI Overviews). 272-check automated audit + AVI (AI Visibility Index) tracking.
 
 ## Contributing
 


### PR DESCRIPTION
Hi! Adding WebCoreLab to the AI SEO Agencies & Tools section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
