### PR TITLE
Add The SEO Autopilot to AI SEO Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
 * **[MarketMuse](https://www.marketmuse.com/)** – Content planning and optimization with AI scoring.
 * **[Scalenut](https://www.scalenut.com/)** – AI-driven SEO content strategy and generation.
 
+* **[The SEO Autopilot](https://the-seo-autopilot.com)** – Autonomous AI agent that runs the entire SEO pipeline (keyword research, fact-checked drafting, schema, internal linking, scheduling) for indie SaaS founders. Ships 13 free in-browser SEO tools (llms.txt generator, JSON-LD schema, SERP CTR calculator, hreflang, canonical, robots, AI overview checker).
+
 ## Open-Source Projects
 
 * **[seo-analyzer](https://github.com/stevenbenner/seo-analyzer)** – Command-line SEO audit tool.


### PR DESCRIPTION
Hi! Adds [The SEO Autopilot](https://the-seo-autopilot.com) to the **AI SEO Platforms** section. It's an autonomous AI-agent SEO system aimed at indie SaaS founders that publishes one fact-checked article per day and ships a free in-browser tool suite (llms.txt generator, JSON-LD schema generator, SERP CTR calculator, hreflang/canonical/robots tag generators, AI overview checker, AI content cost calculator) at https://the-seo-autopilot.com/en/free-tools/.

Followed the existing `* **[Name](URL)** – Description.` bullet format with the en-dash. Happy to move it to a different category if you'd prefer.