### PR TITLE
add elmo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 * **[GPTSEO](https://github.com/gptseo/gptseo)** – AI SEO tool for generating articles and optimizing titles/meta.
 * **[Keyword Clustering Tool (Python)](https://github.com/AndreiMikhalevich/KeywordClustering)** – Cluster keywords using embeddings.
 * **[GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker)** – Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, free, with visibility scoring, citation analysis, and competitor battlecards.
+* **[Elmo](https://github.com/elmohq/elmo)** – Open-source, self-hosted AI visibility tracker. Monitor brand mentions and citations across ChatGPT, Claude, Gemini, and Perplexity, with visibility scoring, citation analysis, and competitor benchmarking.
 
 ## Keyword Research & Clustering
 


### PR DESCRIPTION
Adds my project Elmo (an MIT-licensed, open-source, self-hosted AI visibility tracker) to the "Open-Source Projects " section.