### PR TITLE
Add LinkPost (LinkedIn virality prediction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 * **[Writesonic](https://writesonic.com/)** – Long-form AI writing for SEO.
 * **[Copy.ai](https://www.copy.ai/)** – Generate SEO meta descriptions, intros, and more.
 * **[Content at Scale](https://contentatscale.ai/)** – Fully automated long-form SEO blog generation.
+- [LinkPost](https://linkpost.gg) - AI-powered LinkedIn post writer that predicts virality before publishing using 1M+ posts and 300+ factors.
 
 ## SEO Auditing & On-Page Optimization
 


### PR DESCRIPTION
This PR adds [LinkPost](https://linkpost.gg) to the **Content Generation** section.

## What is LinkPost?

LinkPost is the first scientific approach to LinkedIn content. It analyzes 1M+ posts, scores 300+ measurable factors (22 attention tactics + 11 virality rules + 27 personalized to your writing style), and predicts post virality before publishing (70% precision on sentiment, 90% on debate).

## Why include it here?

- Fits the section: helps creators write higher-performing LinkedIn content
- Active product: V2 publicly launched May 27, 2026
- Public website: https://linkpost.gg
- Trustpilot: 10+ reviews, 100% 5-star
- Used by 100+ paying customers, x1.93 likes on average across active cohort (n=20, 60-day study)

## Disclosure

I'm Yannis Haismann, co-founder of LinkPost. I opened this PR myself rather than asking the community to do it. Happy to adjust formatting, change the wording, or remove it if it's not a good fit. Thanks for maintaining this awesome list!
