### PR TITLE
Add CreatorSkills to Prompt Libraries & Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 * **[AIPRM for ChatGPT](https://www.aiprm.com/)** – Community templates for SEO content and audits.
 * **[FlowGPT SEO Prompts](https://flowgpt.com/)** – SEO prompt marketplace.
 * **[PromptVine](https://promptvine.com/)** – Prompt library with copywriting and SEO sections.
+* **[CreatorSkills](https://creatorskills.co)** – Marketplace of 30+ downloadable AI skills for content creators covering scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
 
 ## Courses & Guides
 


### PR DESCRIPTION
Adds [CreatorSkills](https://creatorskills.co) to the Prompt Libraries & Templates section — a marketplace of 30+ downloadable AI skills for content creators. Sits alongside AIPRM, FlowGPT, and PromptVine as a skills/prompt marketplace, specialized for content creation workflows. Works with Claude and ChatGPT.