### PR TITLE
Add Is My Brand in AI to Technical SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 * **[JetOctopus](https://jetoctopus.com/)** – Cloud-based SEO crawler with insights.
 * **[ContentKing](https://www.contentkingapp.com/)** – Real-time SEO auditing.
 * **[Sitebulb](https://sitebulb.com/)** – Technical audits with visuals and prioritization.
+* **[Is My Brand in AI](https://ismybrandinai.com/tools/ai-bot-checker)** – Free, no-signup tool that reads a site's robots.txt and shows which AI crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, BingBot) it allows or blocks.
 
 ## SERP Tracking & Analytics
 


### PR DESCRIPTION
Adds **Is My Brand in AI** to the Technical SEO section. It's a free, no-signup browser tool that reads a domain's robots.txt and shows which AI crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, BingBot) are allowed or blocked — a quick way to audit AI-crawler access. The entry follows the existing list format. Thanks for maintaining this list!