### PR TITLE
Add NotFair — open-source Claude Code skills for SEO, Google Ads & Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 * **[GPTSEO](https://github.com/gptseo/gptseo)** – AI SEO tool for generating articles and optimizing titles/meta.
 * **[Keyword Clustering Tool (Python)](https://github.com/AndreiMikhalevich/KeywordClustering)** – Cluster keywords using embeddings.
 * **[GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker)** – Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, free, with visibility scoring, citation analysis, and competitor battlecards.
+* **[NotFair](https://github.com/nowork-studio/NotFair)** – MIT-licensed Claude Code plugin (~2.9k stars) with agent skills for [SEO](https://github.com/nowork-studio/NotFair/tree/main/seo), [Google Ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads), and [Meta Ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads). Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to run audits, detect wasted spend, optimize meta tags, generate schema markup, and more.
 
 ## Keyword Research & Clustering
 


### PR DESCRIPTION
Hi, thanks for maintaining this list — it's a great reference.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** to the Open-Source Projects section. It's an MIT-licensed set of Claude Code agent skills (~2.9k stars) covering SEO, Google Ads, and Meta Ads. What makes it distinctive for this list is that it connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — so the skills can run real audits, detect wasted spend, rewrite meta tags, and generate schema markup directly against a user's actual accounts.

The skill areas:
- **SEO** — keyword research, meta tag optimization, schema markup, GEO optimization, content writing
- **Google Ads** — audits, wasted-spend detection, search-term cleanup, bid management
- **Meta Ads** — ROAS analysis, creative fatigue, audience overlap

Happy to reword the description, move it to a different section, or trim it down if you prefer. Thanks for considering it!