### PR TITLE
Add Recommd to AI SEO Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 * **[MarketMuse](https://www.marketmuse.com/)** – Content planning and optimization with AI scoring.
 * **[Scalenut](https://www.scalenut.com/)** – AI-driven SEO content strategy and generation.
 * **[oohoom](https://www.oohoom.com)** – Get the most out of your GSC and GA4 using AI Assistant and MCP
+* **[Recommd](https://recommd.com)** – AI visibility audit for local businesses. Checks whether ChatGPT, Perplexity, and Google AI Overviews recommend a business or a competitor, with a 0-100 score and a plain-English fix plan. Free basic check, no signup.
 
 ## Open-Source Projects
 


### PR DESCRIPTION
Adding **Recommd** to the **AI SEO Platforms** section.

Recommd is a free AI-visibility audit focused on local businesses: it queries ChatGPT, Perplexity, and Google AI Overviews with a real customer question and reports whether the business is recommended or a competitor is named instead, plus a 0-100 visibility score and a plain-English fix plan.

Entry follows the section's `* **[Name](url)** – Description` format. Happy to tweak the wording or placement to fit the list.